### PR TITLE
class dunder repr and str

### DIFF
--- a/disruptive/authentication.py
+++ b/disruptive/authentication.py
@@ -51,6 +51,13 @@ class Auth():
         # Set arguments as attributes
         self.credentials = credentials
 
+    def __repr__(self):
+        return '{}.{}({})'.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self.credentials,
+        )
+
     @classmethod
     def serviceaccount(cls,
                        key_id: str,

--- a/disruptive/events/events.py
+++ b/disruptive/events/events.py
@@ -142,6 +142,16 @@ class Touch(_EventData):
         # Inherit parent _EventData class init with repacked data dictionary.
         _EventData.__init__(self, self.__repack(), 'touch')
 
+    def __repr__(self):
+        string = '{}.{}('\
+            'timestamp={}'\
+            ')'
+        return string.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            repr(dttrans.to_iso8601(self.timestamp)),
+        )
+
     @classmethod
     def _from_raw(cls, data: dict):
         """
@@ -216,6 +226,18 @@ class Temperature(_EventData):
 
         # Inherit parent _EventData class init with repacked data dictionary.
         _EventData.__init__(self, self.__repack(), 'temperature')
+
+    def __repr__(self):
+        string = '{}.{}('\
+            'celsius={}, '\
+            'timestamp={}'\
+            ')'
+        return string.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self.celsius,
+            repr(dttrans.to_iso8601(self.timestamp)),
+        )
 
     @classmethod
     def _from_raw(cls, data: dict):
@@ -310,6 +332,18 @@ class ObjectPresent(_EventData):
         # Inherit parent _EventData class init with repacked data dictionary.
         _EventData.__init__(self, self.__repack(), 'objectPresent')
 
+    def __repr__(self):
+        string = '{}.{}('\
+            'state={}, '\
+            'timestamp={}'\
+            ')'
+        return string.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            repr(self.state),
+            repr(dttrans.to_iso8601(self.timestamp)),
+        )
+
     @classmethod
     def _from_raw(cls, data: dict):
         """
@@ -390,6 +424,20 @@ class Humidity(_EventData):
         # Inherit parent _EventData class init with repacked data dictionary.
         _EventData.__init__(self, self.__repack(), 'humidity')
 
+    def __repr__(self):
+        string = '{}.{}('\
+            'temperature={}, '\
+            'humidity={}, '\
+            'timestamp={}'\
+            ')'
+        return string.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self.temperature,
+            self.humidity,
+            repr(dttrans.to_iso8601(self.timestamp)),
+        )
+
     @classmethod
     def _from_raw(cls, data: dict):
         """
@@ -469,6 +517,18 @@ class ObjectPresentCount(_EventData):
         # Inherit parent _EventData class init with repacked data dictionary.
         _EventData.__init__(self, self.__repack(), 'objectPresentCount')
 
+    def __repr__(self):
+        string = '{}.{}('\
+            'total={}, '\
+            'timestamp={}'\
+            ')'
+        return string.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self.total,
+            repr(dttrans.to_iso8601(self.timestamp)),
+        )
+
     @classmethod
     def _from_raw(cls, data: dict):
         """
@@ -544,6 +604,18 @@ class TouchCount(_EventData):
         # Inherit parent _EventData class init with repacked data dictionary.
         _EventData.__init__(self, self.__repack(), 'touchCount')
 
+    def __repr__(self):
+        string = '{}.{}('\
+            'total={}, '\
+            'timestamp={}'\
+            ')'
+        return string.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self.total,
+            repr(dttrans.to_iso8601(self.timestamp)),
+        )
+
     @classmethod
     def _from_raw(cls, data: dict):
         """
@@ -616,6 +688,18 @@ class WaterPresent(_EventData):
 
         # Inherit parent _EventData class init with repacked data dictionary.
         _EventData.__init__(self, self.__repack(), 'waterPresent')
+
+    def __repr__(self):
+        string = '{}.{}('\
+            'state={}, '\
+            'timestamp={}'\
+            ')'
+        return string.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            repr(self.state),
+            repr(dttrans.to_iso8601(self.timestamp)),
+        )
 
     @classmethod
     def _from_raw(cls, data: dict):
@@ -698,6 +782,20 @@ class NetworkStatusCloudConnector(dtoutputs.OutputBase):
         self.cloudconnector_id = cloudconnector_id
         self.signal_strength = signal_strength
         self.rssi = rssi
+
+    def __repr__(self):
+        string = '{}.{}('\
+            'cloudconnector_id={}, '\
+            'signal_strength={}, '\
+            'rssi={}'\
+            ')'
+        return string.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            repr(self.cloudconnector_id),
+            self.signal_strength,
+            self.rssi,
+        )
 
     @classmethod
     def _from_raw(cls, data: dict):
@@ -790,6 +888,24 @@ class NetworkStatus(_EventData):
 
         # Inherit parent _EventData class init with repacked data dictionary.
         _EventData.__init__(self, self.__repack(), 'networkStatus')
+
+    def __repr__(self):
+        string = '{}.{}('\
+            'signal_strength={}, '\
+            'rssi={}, '\
+            'transmission_mode={}, '\
+            'cloud_connectors={}, '\
+            'timestamp={}'\
+            ')'
+        return string.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self.signal_strength,
+            self.rssi,
+            repr(self.transmission_mode),
+            self.cloud_connectors,
+            repr(dttrans.to_iso8601(self.timestamp)),
+        )
 
     @classmethod
     def _from_raw(cls, data: dict):
@@ -889,6 +1005,18 @@ class BatteryStatus(_EventData):
         # Inherit parent _EventData class init with repacked data dictionary.
         _EventData.__init__(self, self.__repack(), 'batteryStatus')
 
+    def __repr__(self):
+        string = '{}.{}('\
+            'percentage={}, '\
+            'timestamp={}'\
+            ')'
+        return string.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self.percentage,
+            repr(dttrans.to_iso8601(self.timestamp)),
+        )
+
     @classmethod
     def _from_raw(cls, data: dict):
         """
@@ -974,6 +1102,22 @@ class LabelsChanged(_EventData):
 
         # Inherit parent _EventData class init with repacked data dictionary.
         _EventData.__init__(self, self.__repack(), 'labelsChanged')
+
+    def __repr__(self):
+        string = '{}.{}('\
+            'added={}, '\
+            'modified={}, '\
+            'removed={}, '\
+            'timestamp={}'\
+            ')'
+        return string.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self.added,
+            self.modified,
+            self.removed,
+            repr(dttrans.to_iso8601(self.timestamp)),
+        )
 
     @classmethod
     def _from_raw(cls, data: dict):
@@ -1064,6 +1208,20 @@ class ConnectionStatus(_EventData):
         # Inherit parent _EventData class init with repacked data dictionary.
         _EventData.__init__(self, self.__repack(), 'connectionStatus')
 
+    def __repr__(self):
+        string = '{}.{}('\
+            'connection={}, '\
+            'available={}, '\
+            'timestamp={}'\
+            ')'
+        return string.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            repr(self.connection),
+            repr(self.available),
+            repr(dttrans.to_iso8601(self.timestamp)),
+        )
+
     @classmethod
     def _from_raw(cls, data: dict):
         """
@@ -1148,6 +1306,20 @@ class EthernetStatus(_EventData):
         # Inherit parent _EventData class init with repacked data dictionary.
         _EventData.__init__(self, self.__repack(), 'ethernetStatus')
 
+    def __repr__(self):
+        string = '{}.{}('\
+            'mac_address={}, '\
+            'ip_address={}, '\
+            'timestamp={}'\
+            ')'
+        return string.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            repr(self.mac_address),
+            repr(self.ip_address),
+            repr(dttrans.to_iso8601(self.timestamp)),
+        )
+
     @classmethod
     def _from_raw(cls, data: dict):
         """
@@ -1224,6 +1396,18 @@ class CellularStatus(_EventData):
 
         # Inherit parent _EventData class init with repacked data dictionary.
         _EventData.__init__(self, self.__repack(), 'cellularStatus')
+
+    def __repr__(self):
+        string = '{}.{}('\
+            'signal_strength={}, '\
+            'timestamp={}'\
+            ')'
+        return string.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self.signal_strength,
+            repr(dttrans.to_iso8601(self.timestamp)),
+        )
 
     @classmethod
     def _from_raw(cls, data: dict):

--- a/disruptive/outputs.py
+++ b/disruptive/outputs.py
@@ -22,7 +22,7 @@ class OutputBase():
         # Set attribute from input argument.
         self._raw = raw
 
-    def __str__(self):
+    def __repr__(self):
         out = self.__dump([], self, level=0)
         return '\n'.join(out)
 

--- a/disruptive/outputs.py
+++ b/disruptive/outputs.py
@@ -23,10 +23,17 @@ class OutputBase():
         self._raw = raw
 
     def __repr__(self):
-        out = self.__dump([], self, level=0)
+        return '{}.{}({})'.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self._raw,
+        )
+
+    def __str__(self):
+        out = self.__str__recursive([], self, level=0)
         return '\n'.join(out)
 
-    def __dump(self, out, obj, level):
+    def __str__recursive(self, out, obj, level):
         # Set the indent level for formatting.
         n_spaces = 4
         l0 = level*' '*n_spaces
@@ -50,13 +57,13 @@ class OutputBase():
                 out.append('{}{}: {} = {}'.format(
                     l1, a, type(val).__name__,
                     str(val.__class__.__name__) + '('))
-                self.__dump(out, val, level=level+1)
+                self.__str__recursive(out, val, level=level+1)
 
             # Lists content should be iterated through.
             elif isinstance(val, list):
                 out.append('{}{}: {} = {}'.format(
                     l1, a, type(val).__name__, '['))
-                self.__dump_list(out, val, level+1, n_spaces, l1)
+                self.__str__list(out, val, level+1, n_spaces, l1)
                 out.append(l1 + '],')
 
             # Other types can be printed directly.
@@ -70,14 +77,14 @@ class OutputBase():
 
         return out
 
-    def __dump_list(self, out, lst, level, n_spaces, l1):
+    def __str__list(self, out, lst, level, n_spaces, l1):
         for val in lst:
             # Class objects should be dumped recursively.
             if hasattr(val, '__dict__'):
                 out.append('{}{}'.format(
                     l1, str(val.__class__.__name__) + '('
                 ))
-                self.__dump(out, val, level=level+2)
+                self.__str__recursive(out, val, level=level+2)
 
             # Everything else can be printed directly.
             else:

--- a/disruptive/outputs.py
+++ b/disruptive/outputs.py
@@ -27,16 +27,14 @@ class OutputBase():
         return '\n'.join(out)
 
     def __dump(self, out, obj, level):
-        # Set the two formatting indent levels.
+        # Set the indent level for formatting.
         n_spaces = 4
-        ls = level*' '*n_spaces
+        l0 = level*' '*n_spaces
+        l1 = (level+1)*' '*n_spaces
 
-        # Print name of the current object if level is 0.
+        # At first recursive depth, print object name.
         if level == 0:
-            out.append(ls + str(self.__class__.__name__) + ' object:')
-            # out.insert(-1, ls + '_'*len(out[-1]))
-            out.insert(-1, '')
-            out.append(ls + '-'*len(out[-1]))
+            out.append(l0 + str(obj.__class__.__name__) + '(')
 
         # Append the various public attributes recursively.
         for a in vars(obj):
@@ -46,34 +44,45 @@ class OutputBase():
 
             # Fetch and evaluate the attribute value / type.
             val = getattr(obj, a)
+
+            # Class objects should be dumped recursively.
             if hasattr(val, '__dict__'):
-                # Class objects should be dumped recursively.
-                out.append('{}[{}] {}:'.format(ls, type(val).__name__, a))
+                out.append('{}{}: {} = {}'.format(
+                    l1, a, type(val).__name__,
+                    str(val.__class__.__name__) + '('))
                 self.__dump(out, val, level=level+1)
 
+            # Lists content should be iterated through.
             elif isinstance(val, list):
-                # Lists content should be iterated through.
-                out.append('{}[{}] {}:'.format(ls, type(val).__name__, a))
-                self.__dump_list(out, val, level+1)
+                out.append('{}{}: {} = {}'.format(
+                    l1, a, type(val).__name__, '['))
+                self.__dump_list(out, val, level+1, n_spaces, l1)
+                out.append(l1 + '],')
 
+            # Other types can be printed directly.
             else:
-                # Other types can be printed directly.
-                out.append('{}[{}] {}: {}'.format(
-                    ls, type(val).__name__, a, str(val)
+                out.append('{}{}: {} = {},'.format(
+                    l1, a, type(val).__name__, str(val)
                 ))
+
+        # At the end of each recursive depth, end object paranthesis.
+        out.append(l0 + '),')
 
         return out
 
-    def __dump_list(self, out, lst, level):
-        n_spaces = 4
-        ls = (level+1)*' '*n_spaces
+    def __dump_list(self, out, lst, level, n_spaces, l1):
         for val in lst:
+            # Class objects should be dumped recursively.
             if hasattr(val, '__dict__'):
-                out.append('{}[{}]:'.format(ls, type(val).__name__))
+                out.append('{}{}'.format(
+                    l1, str(val.__class__.__name__) + '('
+                ))
                 self.__dump(out, val, level=level+2)
+
+            # Everything else can be printed directly.
             else:
-                out.append('{}[{}] {}'.format(
-                    ls, type(val).__name__, val
+                out.append('{}{} = {},'.format(
+                    l1, type(val).__name__, str(val)
                 ))
         return out
 

--- a/disruptive/outputs.py
+++ b/disruptive/outputs.py
@@ -38,6 +38,7 @@ class OutputBase():
         n_spaces = 4
         l0 = level*' '*n_spaces
         l1 = (level+1)*' '*n_spaces
+        l2 = (level+2)*' '*n_spaces
 
         # At first recursive depth, print object name.
         if level == 0:
@@ -63,7 +64,7 @@ class OutputBase():
             elif isinstance(val, list):
                 out.append('{}{}: {} = {}'.format(
                     l1, a, type(val).__name__, '['))
-                self.__str__list(out, val, level+1, n_spaces, l1)
+                self.__str__list(out, val, level+1, n_spaces, l2)
                 out.append(l1 + '],')
 
             # Other types can be printed directly.

--- a/disruptive/resources/eventhistory.py
+++ b/disruptive/resources/eventhistory.py
@@ -40,6 +40,13 @@ class EventHistory(dtoutputs.OutputBase):
         # Set parameter attributes.
         self.events_list = events_list
 
+    def __repr__(self):
+        return '{}.{}({})'.format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self.events_list,
+        )
+
     @classmethod
     def list_events(cls,
                     device_id: str,

--- a/disruptive/transforms.py
+++ b/disruptive/transforms.py
@@ -33,7 +33,13 @@ def to_iso8601(ts):
     # If not string, datetime is also fine as it can be converted.
     elif isinstance(ts, datetime):
         # Use built-in functions for converting to string.
-        return ts.isoformat() + 'Z'
+        dt = ts.isoformat()
+
+        # Add timezone information if lacking.
+        if '+' not in dt:
+            dt += 'Z'
+
+        return dt
 
     # If ts is None, return None.
     elif ts is None:

--- a/tests/test_dataconnector.py
+++ b/tests/test_dataconnector.py
@@ -2,12 +2,27 @@
 from unittest.mock import patch
 
 # Project imports.
-import disruptive as dt
+import disruptive
 import tests.api_responses as dtapiresponses
 import disruptive.dataconnector_configs.dataconnector_configs as dcon_configs
 
 
 class TestDataconnector():
+
+    def test_repr(self, request_mock):
+        # Update the response data with dataconnector data.
+        res = dtapiresponses.configured_dataconnector
+        request_mock.json = res
+
+        # Fetch a dataconnector.
+        x = disruptive.DataConnector.get_dataconnector(
+            dataconnector_id='dataconnector_id',
+            project_id='project_id',
+        )
+
+        # Evaluate __repr__ function and compare copy.
+        y = eval(repr(x))
+        assert x._raw == y._raw
 
     def test_attributes(self, request_mock):
         # Update the response json with a mock dataconnector response.
@@ -15,7 +30,10 @@ class TestDataconnector():
         request_mock.json = r
 
         # Call the appropriate endpoint.
-        d = dt.DataConnector.get_dataconnector('project_id', 'device_id')
+        d = disruptive.DataConnector.get_dataconnector(
+            dataconnector_id='dataconnector_id',
+            project_id='project_id',
+        )
 
         # Assert attributes unpacked correctly.
         assert d.dataconnector_id == r['name'].split('/')[-1]
@@ -36,7 +54,10 @@ class TestDataconnector():
         request_mock.json = r
 
         # Call an endpoint to construct a dataconnector object.
-        d = dt.DataConnector.get_dataconnector('project_id', 'device_id')
+        d = disruptive.DataConnector.get_dataconnector(
+            dataconnector_id='dataconnector_id',
+            project_id='project_id',
+        )
 
         # Assert config attribute is None.
         assert d.dataconnector_type == 'unknown'
@@ -47,13 +68,14 @@ class TestDataconnector():
         request_mock.json = dtapiresponses.configured_dataconnector
 
         # Call the appropriate endpoint.
-        d = dt.DataConnector.get_dataconnector(
+        d = disruptive.DataConnector.get_dataconnector(
             dataconnector_id='dataconnector_id',
             project_id='project_id',
         )
 
         # Verify expected outgoing parameters in request.
-        url = dt.api_url+'/projects/project_id/dataconnectors/dataconnector_id'
+        url = disruptive.api_url
+        url += '/projects/project_id/dataconnectors/dataconnector_id'
         request_mock.assert_requested(
             method='GET',
             url=url,
@@ -63,17 +85,19 @@ class TestDataconnector():
         request_mock.assert_request_count(1)
 
         # Assert output instance.
-        assert isinstance(d, dt.DataConnector)
+        assert isinstance(d, disruptive.DataConnector)
 
     def test_list_dataconnectors(self, request_mock):
         # Update the response json with a mock dataconnector response.
         request_mock.json = dtapiresponses.paginated_dataconnectors_response
 
         # Call the appropriate endpoint.
-        dataconnectors = dt.DataConnector.list_dataconnectors('project_id')
+        dataconnectors = disruptive.DataConnector.list_dataconnectors(
+            project_id='project_id',
+        )
 
         # Verify expected outgoing parameters in request.
-        url = dt.api_url+'/projects/project_id/dataconnectors'
+        url = disruptive.api_url+'/projects/project_id/dataconnectors'
         request_mock.assert_requested(
             method='GET',
             url=url,
@@ -85,7 +109,7 @@ class TestDataconnector():
         # Assert output as list of instances.
         assert isinstance(dataconnectors, list)
         for d in dataconnectors:
-            assert isinstance(d, dt.DataConnector)
+            assert isinstance(d, disruptive.DataConnector)
 
     def test_create_dataconnector(self, request_mock):
         # Update the response json with a mock dataconnector response.
@@ -93,11 +117,11 @@ class TestDataconnector():
         request_mock.json = res
 
         # Call DataConnector.configured_dataconnector().
-        d = dt.DataConnector.create_dataconnector(
+        d = disruptive.DataConnector.create_dataconnector(
             project_id='c0md3pm0p7bet3vico8g',
             display_name='my-new-dcon',
             labels=['name', 'custom-label-01', 'custom_label-02'],
-            config=dt.dataconnector_configs.HttpPush(
+            config=disruptive.dataconnector_configs.HttpPush(
                 url='https://584087e0a1fa.eu.ngrok.io/api/endpoint',
                 signature_secret='some-very-good-secret',
                 headers={
@@ -109,7 +133,8 @@ class TestDataconnector():
 
         # Verify expected outgoing parameters in request.
         # Especially the body is important here.
-        url = dt.api_url+'/projects/c0md3pm0p7bet3vico8g/dataconnectors'
+        url = disruptive.api_url
+        url += '/projects/c0md3pm0p7bet3vico8g/dataconnectors'
         request_mock.assert_requested(
             method='POST',
             url=url,
@@ -133,7 +158,7 @@ class TestDataconnector():
         request_mock.assert_request_count(1)
 
         # Assert output is instance of DataConnector.
-        assert isinstance(d, dt.DataConnector)
+        assert isinstance(d, disruptive.DataConnector)
 
     def test_create_dataconnector_http_push_config(self, request_mock):
         """
@@ -149,9 +174,9 @@ class TestDataconnector():
             init_mock.return_value = None
 
             # Call DataConnector.create_dataconnector for type HTTP_PUSH.
-            dt.DataConnector.create_dataconnector(
+            disruptive.DataConnector.create_dataconnector(
                 project_id='project_id',
-                config=dt.dataconnector_configs.HttpPush(
+                config=disruptive.dataconnector_configs.HttpPush(
                     url='some-url',
                     signature_secret='some-secret',
                     headers={'name': 'value'},
@@ -160,7 +185,7 @@ class TestDataconnector():
 
         # Verify expected outgoing parameters in request.
         # Especially the body is important here.
-        url = dt.api_url+'/projects/project_id/dataconnectors'
+        url = disruptive.api_url+'/projects/project_id/dataconnectors'
         request_mock.assert_requested(
             method='POST',
             url=url,
@@ -185,12 +210,12 @@ class TestDataconnector():
         request_mock.json = res
 
         # Call DataConnector.configured_dataconnector().
-        d = dt.DataConnector.update_dataconnector(
+        d = disruptive.DataConnector.update_dataconnector(
             dataconnector_id='c16pegipidie7lltrefg',
             project_id='c0md3pm0p7bet3vico8g',
             display_name='my-new-dcon',
             labels=['name', 'custom-label-01', 'custom_label-02'],
-            config=dt.dataconnector_configs.HttpPush(
+            config=disruptive.dataconnector_configs.HttpPush(
                 url='https://584087e0a1fa.eu.ngrok.io/api/endpoint',
                 signature_secret='some-very-good-secret',
                 headers={
@@ -202,7 +227,7 @@ class TestDataconnector():
 
         # Verify expected outgoing parameters in request.
         # Especially the body is important here.
-        url = dt.api_url
+        url = disruptive.api_url
         url += '/projects/c0md3pm0p7bet3vico8g'
         url += '/dataconnectors/c16pegipidie7lltrefg'
         request_mock.assert_requested(
@@ -226,7 +251,7 @@ class TestDataconnector():
         request_mock.assert_request_count(1)
 
         # Assert output is instance of DataConnector.
-        assert isinstance(d, dt.DataConnector)
+        assert isinstance(d, disruptive.DataConnector)
 
     def test_update_dataconnector_change_nothing(self, request_mock):
         """
@@ -244,13 +269,14 @@ class TestDataconnector():
 
             # Call DataConnector.configured_dataconnector() with only
             # required parameters, basically asking the API to change nothing.
-            dt.DataConnector.update_dataconnector(
+            disruptive.DataConnector.update_dataconnector(
                 dataconnector_id='dataconnector_id',
                 project_id='project_id',
             )
 
         # Verify that all optional parameters are not included in the body.
-        url = dt.api_url+'/projects/project_id/dataconnectors/dataconnector_id'
+        url = disruptive.api_url
+        url += '/projects/project_id/dataconnectors/dataconnector_id'
         request_mock.assert_requested(
             method='PATCH',
             url=url,
@@ -259,13 +285,14 @@ class TestDataconnector():
 
     def test_delete_dataconnector(self, request_mock):
         # Call the DataConnector.delete_dataconnector() method.
-        d = dt.DataConnector.delete_dataconnector(
+        d = disruptive.DataConnector.delete_dataconnector(
             dataconnector_id='dataconnector_id',
             project_id='project_id',
         )
 
         # Verify expected outgoing parameters in request.
-        url = dt.api_url+'/projects/project_id/dataconnectors/dataconnector_id'
+        url = disruptive.api_url
+        url += '/projects/project_id/dataconnectors/dataconnector_id'
         request_mock.assert_requested(
             method='DELETE',
             url=url,
@@ -282,13 +309,13 @@ class TestDataconnector():
         request_mock.json = dtapiresponses.metrics
 
         # Call DataConnector.get_metrics.
-        m = dt.DataConnector.get_metrics(
+        m = disruptive.DataConnector.get_metrics(
             dataconnector_id='dataconnector_id',
             project_id='project_id',
         )
 
         # Verify expected outgoing parameters in request.
-        url = dt.api_url
+        url = disruptive.api_url
         url += '/projects/project_id/dataconnectors/dataconnector_id:metrics'
         request_mock.assert_requested(
             method='GET',
@@ -299,17 +326,17 @@ class TestDataconnector():
         request_mock.assert_request_count(1)
 
         # Assert output is instance of Metric.
-        assert isinstance(m, dt.resources.dataconnector.Metric)
+        assert isinstance(m, disruptive.resources.dataconnector.Metric)
 
     def test_sync_dataconnector(self, request_mock):
         # Call DataConnector.sync_dataconnector.
-        m = dt.DataConnector.sync_dataconnector(
+        m = disruptive.DataConnector.sync_dataconnector(
             dataconnector_id='dataconnector_id',
             project_id='project_id',
         )
 
         # Verify expected outgoing parameters in request.
-        url = dt.api_url
+        url = disruptive.api_url
         url += '/projects/project_id/dataconnectors/dataconnector_id:sync'
         request_mock.assert_requested(
             method='POST',
@@ -333,14 +360,14 @@ class TestDataconnector():
         request_mock.json = r
 
         # Call the appropriate endpoint.
-        d = dt.DataConnector.get_dataconnector(
+        d = disruptive.DataConnector.get_dataconnector(
             dataconnector_id='c16eegpdidie7lltpefg',
             project_id='c0md3mm0c7pet3vico8g',
         )
 
         # Assert type and config instance.
         assert d.dataconnector_type == 'HTTP_PUSH'
-        assert isinstance(d.config, dt.dataconnector_configs.HttpPush)
+        assert isinstance(d.config, disruptive.dataconnector_configs.HttpPush)
 
         # Assert HttpPush attributes are set properly.
         assert d.config.url == r['httpConfig']['url']
@@ -355,7 +382,7 @@ class TestDataconnector():
         """
 
         # Construct a HttpPush object.
-        config = dt.dataconnector_configs.HttpPush(
+        config = disruptive.dataconnector_configs.HttpPush(
             url='some-url',
             signature_secret='some-secret',
             headers={

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,10 +1,22 @@
 # Project imports.
-import disruptive as dt
+import disruptive
 import disruptive.events.events as dtevents
 import tests.api_responses as dtapiresponses
 
 
 class TestDevice():
+
+    def test_repr(self, request_mock):
+        # Update the response data with device data.
+        res = dtapiresponses.touch_sensor
+        request_mock.json = res
+
+        # Fetch a device.
+        x = disruptive.Device.get_device('device_id', 'project_id')
+
+        # Evaluate __repr__ function and compare copy.
+        y = eval(repr(x))
+        assert x._raw == y._raw
 
     def test_unpack(self, request_mock):
         # Update the response data with device data.
@@ -12,7 +24,7 @@ class TestDevice():
         request_mock.json = res
 
         # Call the appropriate endpoint.
-        d = dt.Device.get_device('device_id', 'project_id')
+        d = disruptive.Device.get_device('device_id', 'project_id')
 
         # Assert attributes unpacked correctly.
         assert d.device_id == res['name'].split('/')[-1]
@@ -23,29 +35,29 @@ class TestDevice():
         request_mock.json = dtapiresponses.touch_sensor
 
         # Call Device.get_device() method.
-        d = dt.Device.get_device('device_id', 'project_id')
+        d = disruptive.Device.get_device('device_id', 'project_id')
 
         # Verify expected outgoing parameters in request.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/projects/project_id/devices/device_id',
+            url=disruptive.api_url+'/projects/project_id/devices/device_id',
         )
 
         # Assert single request sent.
         request_mock.assert_request_count(1)
 
         # Assert instance of Device object.
-        assert isinstance(d, dt.Device)
+        assert isinstance(d, disruptive.Device)
 
     def test_list_devices(self, request_mock):
         # Update the response data with a list of device data.
         request_mock.json = dtapiresponses.paginated_device_response
 
         # Call Device.list_devices() method.
-        devices = dt.Device.list_devices('project_id')
+        devices = disruptive.Device.list_devices('project_id')
 
         # Verify expected outgoing parameters in request.
-        url = dt.api_url+'/projects/project_id/devices'
+        url = disruptive.api_url+'/projects/project_id/devices'
         request_mock.assert_requested(
             method='GET',
             url=url,
@@ -59,11 +71,11 @@ class TestDevice():
 
         # Assert output is list of Device.
         for d in devices:
-            assert isinstance(d, dt.Device)
+            assert isinstance(d, disruptive.Device)
 
     def test_batch_update_labels(self, request_mock):
         # Call Device.batch_update_labels() method.
-        d = dt.Device.batch_update_labels(
+        d = disruptive.Device.batch_update_labels(
             device_ids=['device_id1', 'device_id2', 'device_id3'],
             project_id='project_id',
             set_labels={
@@ -74,7 +86,7 @@ class TestDevice():
         )
 
         # Verify expected outgoing parameters in request.
-        url = dt.api_url+'/projects/project_id/devices:batchUpdate'
+        url = disruptive.api_url+'/projects/project_id/devices:batchUpdate'
         request_mock.assert_requested(
             method='POST',
             url=url,
@@ -97,7 +109,7 @@ class TestDevice():
 
     def test_set_label(self, request_mock):
         # Call Device.set_label() method.
-        d = dt.Device.set_label(
+        d = disruptive.Device.set_label(
             device_id='device_id',
             project_id='project_id',
             key='key',
@@ -105,7 +117,7 @@ class TestDevice():
         )
 
         # Verify expected outgoing parameters in request.
-        url = dt.api_url+'/projects/project_id/devices:batchUpdate'
+        url = disruptive.api_url+'/projects/project_id/devices:batchUpdate'
         request_mock.assert_requested(
             method='POST',
             url=url,
@@ -125,14 +137,14 @@ class TestDevice():
 
     def test_remove_label(self, request_mock):
         # Call Device.remove_label() method.
-        d = dt.Device.remove_label(
+        d = disruptive.Device.remove_label(
             device_id='device_id',
             project_id='project_id',
             key='key',
         )
 
         # Verify expected outgoing parameters in request.
-        url = dt.api_url+'/projects/project_id/devices:batchUpdate'
+        url = disruptive.api_url+'/projects/project_id/devices:batchUpdate'
         request_mock.assert_requested(
             method='POST',
             url=url,
@@ -152,14 +164,14 @@ class TestDevice():
 
     def test_transfer_devices(self, request_mock):
         # Call Device.remove_label() method.
-        d = dt.Device.transfer_devices(
+        d = disruptive.Device.transfer_devices(
             device_ids=['device_id1', 'device_id2'],
             source_project_id='source_project',
             target_project_id='target_project',
         )
 
         # Verify expected outgoing parameters in request.
-        url = dt.api_url+'/projects/target_project/devices:transfer'
+        url = disruptive.api_url+'/projects/target_project/devices:transfer'
         request_mock.assert_requested(
             method='POST',
             url=url,
@@ -182,7 +194,7 @@ class TestDevice():
         request_mock.json = dtapiresponses.null_reported_sensor
 
         # Call the appropriate endpoint.
-        d = dt.Device.get_device('device_id', 'project_id')
+        d = disruptive.Device.get_device('device_id', 'project_id')
 
         # Assert None for all reported datas.
         for key in dtevents._EVENTS_MAP._api_names:
@@ -198,7 +210,7 @@ class TestDevice():
         request_mock.json = dtapiresponses.touch_sensor
 
         # Call the appropriate endpoint.
-        d = dt.Device.get_device('device_id', 'project_id')
+        d = disruptive.Device.get_device('device_id', 'project_id')
 
         # Assert appropriate reported data instances.
         assert isinstance(d.reported.network_status, dtevents.NetworkStatus)

--- a/tests/test_eventhistory.py
+++ b/tests/test_eventhistory.py
@@ -2,12 +2,27 @@
 from datetime import datetime
 
 # Project imports.
-import disruptive as dt
+import disruptive
 from disruptive.events.events import _EVENTS_MAP
 import tests.api_responses as dtapiresponses
 
 
 class TestEventHistory():
+
+    def test_repr(self, request_mock):
+        # Update the response data with eventhistory data.
+        res = dtapiresponses.event_history_each_type
+        request_mock.json = res
+
+        # Fetch eventhistory for a device.
+        x = disruptive.EventHistory.list_events(
+            device_id='device_id',
+            project_id='project_id',
+        )
+
+        # Evaluate __repr__ function and compare copy.
+        y = eval(repr(x))
+        assert x._raw == y._raw
 
     def test_unpack(self, request_mock):
         # Update the response data with event history data.
@@ -15,27 +30,28 @@ class TestEventHistory():
         request_mock.json = res
 
         # Call EventHistory.list_events() method.
-        h = dt.EventHistory.list_events(
+        h = disruptive.EventHistory.list_events(
             device_id='device_id',
             project_id='project_id',
         )
 
         # Assert attributes in h is in expected form.
-        assert isinstance(h, dt.EventHistory)
+        assert isinstance(h, disruptive.EventHistory)
         assert isinstance(h.events_list, list)
         assert len(h.events_list) == len(res['events'])
 
         # Check that events in history are correct object types.
         for event in h.events_list:
             # event should be instance of Event.
-            assert isinstance(event, dt.events.Event)
+            assert isinstance(event, disruptive.events.Event)
 
-            # Here we determine if the correct event data class in dt.events
-            # is constructed based on the provided event_type. We do this by
-            # using the internal _EVENTS_MAP object to map between the two.
+            # Here we determine if the correct event data class in
+            # disruptive.events is constructed based on the provided
+            # event_type. We do this by using the internal _EVENTS_MAP object
+            # to map between the two.
             event_type = event.event_type
             expected = getattr(
-                dt.events,
+                disruptive.events,
                 _EVENTS_MAP._api_names[event_type].class_name
             )
             assert isinstance(event.data, expected)
@@ -46,7 +62,7 @@ class TestEventHistory():
         request_mock.json = res
 
         # Call EventHistory.list_events() method.
-        h = dt.EventHistory.list_events(
+        h = disruptive.EventHistory.list_events(
             device_id='device_id',
             project_id='project_id',
             event_types=['temperature', 'touch'],
@@ -55,9 +71,11 @@ class TestEventHistory():
         )
 
         # Verify expected outgoing parameters in request.
+        url = disruptive.api_url
+        url += '/projects/project_id/devices/device_id/events'
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/projects/project_id/devices/device_id/events',
+            url=url,
             params={
                 'eventTypes': ['temperature', 'touch'],
                 'startTime': '1970-01-01T00:00:00Z',
@@ -69,7 +87,7 @@ class TestEventHistory():
         request_mock.assert_request_count(1)
 
         # Assert instance of EventHistory object.
-        assert isinstance(h, dt.EventHistory)
+        assert isinstance(h, disruptive.EventHistory)
 
     def test_get_events(self, request_mock):
         # Update the response data with event history data.
@@ -77,7 +95,7 @@ class TestEventHistory():
         request_mock.json = res
 
         # Call EventHistory.list_events() method.
-        h = dt.EventHistory.list_events(
+        h = disruptive.EventHistory.list_events(
             device_id='device_id',
             project_id='project_id',
         )
@@ -92,7 +110,10 @@ class TestEventHistory():
                 assert e.event_type == etype
 
             # Also assert data is instance type.
-            exp = getattr(dt.events, _EVENTS_MAP._api_names[etype].class_name)
+            exp = getattr(
+                disruptive.events,
+                _EVENTS_MAP._api_names[etype].class_name
+            )
             assert isinstance(e.data, exp)
 
     def test_get_data_axes(self, request_mock):
@@ -101,7 +122,7 @@ class TestEventHistory():
         request_mock.json = res
 
         # Call EventHistory.list_events() method.
-        h = dt.EventHistory.list_events(
+        h = disruptive.EventHistory.list_events(
             device_id='device_id',
             project_id='project_id',
         )

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -1,9 +1,23 @@
 # Project imports.
-import disruptive as dt
+import disruptive
 import tests.api_responses as dtapiresponses
 
 
 class TestOrganization():
+
+    def test_repr(self, request_mock):
+        # Update the response data with organization data.
+        res = dtapiresponses.organization
+        request_mock.json = res
+
+        # Fetch an organization.
+        x = disruptive.Organization.get_organization(
+            organization_id='organization_id',
+        )
+
+        # Evaluate __repr__ function and compare copy.
+        y = eval(repr(x))
+        assert x._raw == y._raw
 
     def test_unpack(self, request_mock):
         # Update the response data with organization data.
@@ -11,7 +25,7 @@ class TestOrganization():
         request_mock.json = res
 
         # Call the appropriate endpoint.
-        o = dt.Organization.get_organization('organization_id')
+        o = disruptive.Organization.get_organization('organization_id')
 
         # Assert attributes unpacked correctly.
         assert o.id == res['name'].split('/')[-1]
@@ -22,31 +36,31 @@ class TestOrganization():
         request_mock.json = dtapiresponses.organization
 
         # Call the appropriate endpoint.
-        o = dt.Organization.get_organization('organization_id')
+        o = disruptive.Organization.get_organization('organization_id')
 
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/organizations/organization_id',
+            url=disruptive.api_url+'/organizations/organization_id',
         )
 
         # Assert single request sent.
         request_mock.assert_request_count(1)
 
         # Assert attributes in output Organization object.
-        assert isinstance(o, dt.Organization)
+        assert isinstance(o, disruptive.Organization)
 
     def test_list_organizations(self, request_mock):
         # Update the response data with list of organization data.
         request_mock.json = dtapiresponses.organizations
 
         # Call the appropriate endpoint
-        orgs = dt.Organization.list_organizations()
+        orgs = disruptive.Organization.list_organizations()
 
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/organizations',
+            url=disruptive.api_url+'/organizations',
         )
 
         # Assert single request sent.
@@ -54,19 +68,19 @@ class TestOrganization():
 
         # Assert instances of Organization in output list.
         for o in orgs:
-            assert isinstance(o, dt.Organization)
+            assert isinstance(o, disruptive.Organization)
 
     def test_list_members(self, request_mock):
         # Update the response data with list of member data.
         request_mock.json = dtapiresponses.members
 
         # Call the appropriate endpoint
-        members = dt.Organization.list_members('org_id')
+        members = disruptive.Organization.list_members('org_id')
 
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/organizations/org_id/members',
+            url=disruptive.api_url+'/organizations/org_id/members',
         )
 
         # Assert single request sent.
@@ -74,14 +88,14 @@ class TestOrganization():
 
         # Assert instances of Member in output list.
         for m in members:
-            assert isinstance(m, dt.outputs.Member)
+            assert isinstance(m, disruptive.outputs.Member)
 
     def test_add_member(self, request_mock):
         # Update the response data with member data.
         request_mock.json = dtapiresponses.serviceaccount_member
 
         # Call the appropriate endpoint
-        member = dt.Organization.add_member(
+        member = disruptive.Organization.add_member(
             organization_id='org_id',
             email='serviceaccount_email@domain.com',
             roles=['organization.admin'],
@@ -90,7 +104,7 @@ class TestOrganization():
         # Verify request parameters.
         request_mock.assert_requested(
             method='POST',
-            url=dt.api_url+'/organizations/org_id/members',
+            url=disruptive.api_url+'/organizations/org_id/members',
             body={
                 'roles': ['roles/organization.admin'],
                 'email': 'serviceaccount_email@domain.com',
@@ -101,14 +115,14 @@ class TestOrganization():
         request_mock.assert_request_count(1)
 
         # Assert output is instances of Member.
-        assert isinstance(member, dt.outputs.Member)
+        assert isinstance(member, disruptive.outputs.Member)
 
     def test_get_member(self, request_mock):
         # Update the response data with member data.
         request_mock.json = dtapiresponses.serviceaccount_member
 
         # Call the appropriate endpoint
-        member = dt.Organization.get_member(
+        member = disruptive.Organization.get_member(
             organization_id='org_id',
             member_id='member_id',
         )
@@ -116,21 +130,21 @@ class TestOrganization():
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/organizations/org_id/members/member_id',
+            url=disruptive.api_url+'/organizations/org_id/members/member_id',
         )
 
         # Assert single request sent.
         request_mock.assert_request_count(1)
 
         # Assert output is instances of Member.
-        assert isinstance(member, dt.outputs.Member)
+        assert isinstance(member, disruptive.outputs.Member)
 
     def test_remove_member(self, request_mock):
         # Update the response with status code 200.
         request_mock.status_code = 200
 
         # Call the appropriate endpoint
-        response = dt.Organization.remove_member(
+        response = disruptive.Organization.remove_member(
             organization_id='org_id',
             member_id='member_id',
         )
@@ -138,7 +152,7 @@ class TestOrganization():
         # Verify request parameters.
         request_mock.assert_requested(
             method='DELETE',
-            url=dt.api_url+'/organizations/org_id/members/member_id',
+            url=disruptive.api_url+'/organizations/org_id/members/member_id',
         )
 
         # Assert single request sent.
@@ -153,7 +167,7 @@ class TestOrganization():
         request_mock.json = res
 
         # Call the appropriate endpoint
-        response = dt.Organization.get_member_invite_url(
+        response = disruptive.Organization.get_member_invite_url(
             organization_id='org_id',
             member_id='member_id',
         )
@@ -161,7 +175,7 @@ class TestOrganization():
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/organizations/org_id/members/'
+            url=disruptive.api_url+'/organizations/org_id/members/'
             + 'member_id:getInviteUrl',
         )
 
@@ -176,7 +190,7 @@ class TestOrganization():
         request_mock.json = dtapiresponses.organization_permissions
 
         # Call the appropriate endpoint
-        response = dt.Organization.list_permissions(
+        response = disruptive.Organization.list_permissions(
             organization_id='org_id',
         )
 
@@ -186,7 +200,7 @@ class TestOrganization():
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/organizations/org_id/permissions'
+            url=disruptive.api_url+'/organizations/org_id/permissions'
         )
 
         # Assert single request sent.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,9 +1,23 @@
 # Project imports.
-import disruptive as dt
+import disruptive
 import tests.api_responses as dtapiresponses
 
 
 class TestProject():
+
+    def test_repr(self, request_mock):
+        # Update the response data with project data.
+        res = dtapiresponses.small_project
+        request_mock.json = res
+
+        # Fetch a project.
+        x = disruptive.Project.get_project(
+            project_id='project_id',
+        )
+
+        # Evaluate __repr__ function and compare copy.
+        y = eval(repr(x))
+        assert x._raw == y._raw
 
     def test_unpack(self, request_mock):
         # Update the response data with project data.
@@ -11,7 +25,7 @@ class TestProject():
         request_mock.json = res
 
         # Call the appropriate endpoint.
-        p = dt.Project.get_project('project_id')
+        p = disruptive.Project.get_project('project_id')
 
         # Assert attributes unpacked correctly.
         assert p.id == res['name'].split('/')[-1]
@@ -26,31 +40,31 @@ class TestProject():
         request_mock.json = dtapiresponses.small_project
 
         # Call the appropriate endpoint.
-        p = dt.Project.get_project('project_id')
+        p = disruptive.Project.get_project('project_id')
 
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/projects/project_id',
+            url=disruptive.api_url+'/projects/project_id',
         )
 
         # Assert single request sent.
         request_mock.assert_request_count(1)
 
         # Assert output is instance of Project.
-        assert isinstance(p, dt.Project)
+        assert isinstance(p, disruptive.Project)
 
     def test_list_projects(self, request_mock):
         # Update the response data with list of project data.
         request_mock.json = dtapiresponses.projects
 
         # Call the appropriate endpoint
-        projects = dt.Project.list_projects()
+        projects = disruptive.Project.list_projects()
 
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/projects',
+            url=disruptive.api_url+'/projects',
         )
 
         # Assert single request sent.
@@ -58,19 +72,19 @@ class TestProject():
 
         # Assert instances of Project in output list.
         for p in projects:
-            assert isinstance(p, dt.Project)
+            assert isinstance(p, disruptive.Project)
 
     def test_create_project(self, request_mock):
         # Update the response data with project data.
         request_mock.json = dtapiresponses.empty_project
 
         # Call the appropriate endpoint.
-        p = dt.Project.create_project('org', 'name')
+        p = disruptive.Project.create_project('org', 'name')
 
         # Verify request parameters.
         request_mock.assert_requested(
             method='POST',
-            url=dt.api_url+'/projects',
+            url=disruptive.api_url+'/projects',
             body={'organization': 'organizations/org', 'displayName': 'name'},
         )
 
@@ -78,19 +92,19 @@ class TestProject():
         request_mock.assert_request_count(1)
 
         # Assert output is instance of Project.
-        assert isinstance(p, dt.Project)
+        assert isinstance(p, disruptive.Project)
 
     def test_update_project(self, request_mock):
         # Update the response data with project data.
         request_mock.json = dtapiresponses.empty_project
 
         # Call the appropriate endpoint.
-        output = dt.Project.update_project('project_id', 'new-name')
+        output = disruptive.Project.update_project('project_id', 'new-name')
 
         # Verify request parameters.
         request_mock.assert_requested(
             method='PATCH',
-            url=dt.api_url+'/projects/project_id',
+            url=disruptive.api_url+'/projects/project_id',
             body={'displayName': 'new-name'},
         )
 
@@ -102,12 +116,12 @@ class TestProject():
 
     def test_delete_project(self, request_mock):
         # Call the appropriate endpoint.
-        output = dt.Project.delete_project('project_id')
+        output = disruptive.Project.delete_project('project_id')
 
         # Verify request parameters.
         request_mock.assert_requested(
             method='DELETE',
-            url=dt.api_url+'/projects/project_id',
+            url=disruptive.api_url+'/projects/project_id',
         )
 
         # Assert single request sent.
@@ -121,12 +135,12 @@ class TestProject():
         request_mock.json = dtapiresponses.members
 
         # Call the appropriate endpoint
-        members = dt.Project.list_members('project_id')
+        members = disruptive.Project.list_members('project_id')
 
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/projects/project_id/members',
+            url=disruptive.api_url+'/projects/project_id/members',
         )
 
         # Assert single request sent.
@@ -134,7 +148,7 @@ class TestProject():
 
         # Assert instances of Member in output list.
         for m in members:
-            assert isinstance(m, dt.outputs.Member)
+            assert isinstance(m, disruptive.outputs.Member)
 
     def test_add_member(self, request_mock):
         # Update the response data with member data.
@@ -142,7 +156,7 @@ class TestProject():
         request_mock.json = res
 
         # Call the appropriate endpoint
-        member = dt.Project.add_member(
+        member = disruptive.Project.add_member(
             project_id='project_id',
             email='serviceaccount_email@domain.com',
             roles=['project.developer'],
@@ -151,7 +165,7 @@ class TestProject():
         # Verify request parameters.
         request_mock.assert_requested(
             method='POST',
-            url=dt.api_url+'/projects/project_id/members',
+            url=disruptive.api_url+'/projects/project_id/members',
             body={
                 'roles': ['roles/project.developer'],
                 'email': 'serviceaccount_email@domain.com',
@@ -162,14 +176,14 @@ class TestProject():
         request_mock.assert_request_count(1)
 
         # Assert output is instance of Member.
-        assert isinstance(member, dt.outputs.Member)
+        assert isinstance(member, disruptive.outputs.Member)
 
     def test_get_member(self, request_mock):
         # Update the response data with member data.
         request_mock.json = dtapiresponses.user_member
 
         # Call the appropriate endpoint
-        member = dt.Project.get_member(
+        member = disruptive.Project.get_member(
             project_id='project_id',
             member_id='member_id',
         )
@@ -177,21 +191,21 @@ class TestProject():
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/projects/project_id/members/member_id',
+            url=disruptive.api_url+'/projects/project_id/members/member_id',
         )
 
         # Assert single request sent.
         request_mock.assert_request_count(1)
 
         # Assert output is instance of Member.
-        assert isinstance(member, dt.outputs.Member)
+        assert isinstance(member, disruptive.outputs.Member)
 
     def test_update_member(self, request_mock):
         # Update the response data with member data.
         request_mock.json = dtapiresponses.user_member
 
         # Call the appropriate endpoint
-        member = dt.Project.update_member(
+        member = disruptive.Project.update_member(
             project_id='project_id',
             member_id='member_id',
             roles=['project.developer'],
@@ -200,7 +214,7 @@ class TestProject():
         # Verify request parameters.
         request_mock.assert_requested(
             method='PATCH',
-            url=dt.api_url+'/projects/project_id/members/member_id',
+            url=disruptive.api_url+'/projects/project_id/members/member_id',
             body={'roles': ['roles/project.developer']}
         )
 
@@ -208,14 +222,14 @@ class TestProject():
         request_mock.assert_request_count(1)
 
         # Assert output is instance of Member.
-        assert isinstance(member, dt.outputs.Member)
+        assert isinstance(member, disruptive.outputs.Member)
 
     def test_remove_member(self, request_mock):
         # Update the response with status code 200.
         request_mock.status_code = 200
 
         # Call the appropriate endpoint
-        response = dt.Project.remove_member(
+        response = disruptive.Project.remove_member(
             project_id='project_id',
             member_id='member_id',
         )
@@ -223,7 +237,7 @@ class TestProject():
         # Verify request parameters.
         request_mock.assert_requested(
             method='DELETE',
-            url=dt.api_url+'/projects/project_id/members/member_id',
+            url=disruptive.api_url+'/projects/project_id/members/member_id',
         )
 
         # Assert single request sent.
@@ -238,7 +252,7 @@ class TestProject():
         request_mock.json = res
 
         # Call the appropriate endpoint
-        response = dt.Project.get_member_invite_url(
+        response = disruptive.Project.get_member_invite_url(
             project_id='project_id',
             member_id='member_id',
         )
@@ -246,7 +260,7 @@ class TestProject():
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/projects/project_id/members/'
+            url=disruptive.api_url+'/projects/project_id/members/'
             + 'member_id:getInviteUrl',
         )
 
@@ -261,7 +275,7 @@ class TestProject():
         request_mock.json = dtapiresponses.project_permissions
 
         # Call the appropriate endpoint
-        response = dt.Project.list_permissions(
+        response = disruptive.Project.list_permissions(
             project_id='project_id',
         )
 
@@ -271,7 +285,7 @@ class TestProject():
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/projects/project_id/permissions'
+            url=disruptive.api_url+'/projects/project_id/permissions'
         )
 
         # Assert single request sent.

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -1,9 +1,23 @@
 # Project imports.
-import disruptive as dt
+import disruptive
 import tests.api_responses as dtapiresponses
 
 
 class TestRole():
+
+    def test_repr(self, request_mock):
+        # Update the response data with role data.
+        res = dtapiresponses.project_user_role
+        request_mock.json = res
+
+        # Fetch a role.
+        x = disruptive.Role.get_role(
+            role='project_user',
+        )
+
+        # Evaluate __repr__ function and compare copy.
+        y = eval(repr(x))
+        assert x._raw == y._raw
 
     def test_unpack(self, request_mock):
         # Update the response data with project data.
@@ -11,7 +25,7 @@ class TestRole():
         request_mock.json = res
 
         # Call the appropriate endpoint.
-        p = dt.Role.get_role('project.user')
+        p = disruptive.Role.get_role('project.user')
 
         # Assert attributes unpacked correctly.
         assert p.role == res['name'].split('/')[-1]
@@ -24,31 +38,31 @@ class TestRole():
         request_mock.json = dtapiresponses.project_developer_role
 
         # Call the appropriate endpoint.
-        r = dt.Role.get_role('project.developer')
+        r = disruptive.Role.get_role('project.developer')
 
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/roles/project.developer',
+            url=disruptive.api_url+'/roles/project.developer',
         )
 
         # Assert single request sent.
         request_mock.assert_request_count(1)
 
         # Assert output is instance of Role.
-        assert isinstance(r, dt.Role)
+        assert isinstance(r, disruptive.Role)
 
     def test_list_roles(self, request_mock):
         # Update the response data with list of role data.
         request_mock.json = dtapiresponses.roles
 
         # Call the appropriate endpoint
-        roles = dt.Role.list_roles()
+        roles = disruptive.Role.list_roles()
 
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/roles',
+            url=disruptive.api_url+'/roles',
         )
 
         # Assert single request sent.
@@ -56,4 +70,4 @@ class TestRole():
 
         # Assert instances of Role in output list.
         for r in roles:
-            assert isinstance(r, dt.Role)
+            assert isinstance(r, disruptive.Role)

--- a/tests/test_serviceaccount.py
+++ b/tests/test_serviceaccount.py
@@ -1,5 +1,5 @@
 # Project imports.
-import disruptive as dt
+import disruptive
 import tests.api_responses as dtapiresponses
 import disruptive.transforms as dttrans
 from disruptive.resources.serviceaccount import Key
@@ -7,13 +7,28 @@ from disruptive.resources.serviceaccount import Key
 
 class TestServiceAccount():
 
+    def test_repr(self, request_mock):
+        # Update the response data with serviceaccount data.
+        res = dtapiresponses.serviceaccount1
+        request_mock.json = res
+
+        # Fetch a serviceaccount.
+        x = disruptive.ServiceAccount.get_serviceaccount(
+            serviceaccount_id='serviceaccount_id',
+            project_id='project_id',
+        )
+
+        # Evaluate __repr__ function and compare copy.
+        y = eval(repr(x))
+        assert x._raw == y._raw
+
     def test_unpack(self, request_mock):
         # Update the response data with serviceaccount data.
         res = dtapiresponses.serviceaccount1
         request_mock.json = res
 
         # Call the appropriate endpoint.
-        s = dt.ServiceAccount.get_serviceaccount(
+        s = disruptive.ServiceAccount.get_serviceaccount(
             'serviceaccount_id',
             'project_id',
         )
@@ -31,7 +46,7 @@ class TestServiceAccount():
         request_mock.json = dtapiresponses.serviceaccount1
 
         # Call the appropriate endpoint.
-        s = dt.ServiceAccount.get_serviceaccount(
+        s = disruptive.ServiceAccount.get_serviceaccount(
             'serviceaccount_id',
             'project_id',
         )
@@ -39,7 +54,7 @@ class TestServiceAccount():
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/projects/project_id/'
+            url=disruptive.api_url+'/projects/project_id/'
             + 'serviceaccounts/serviceaccount_id',
         )
 
@@ -47,21 +62,21 @@ class TestServiceAccount():
         request_mock.assert_request_count(1)
 
         # Assert attributes in output Device object.
-        assert isinstance(s, dt.ServiceAccount)
+        assert isinstance(s, disruptive.ServiceAccount)
 
     def test_list_serviceaccounts(self, request_mock):
         # Update the response data with list of serviceaccount data.
         request_mock.json = dtapiresponses.serviceaccounts
 
         # Call the appropriate endpoint
-        sas = dt.ServiceAccount.list_serviceaccounts(
+        sas = disruptive.ServiceAccount.list_serviceaccounts(
             'project_id',
         )
 
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/projects/project_id/serviceaccounts',
+            url=disruptive.api_url+'/projects/project_id/serviceaccounts',
         )
 
         # Verify single request sent.
@@ -69,14 +84,14 @@ class TestServiceAccount():
 
         # Assert instances of Project in output list.
         for s in sas:
-            assert isinstance(s, dt.ServiceAccount)
+            assert isinstance(s, disruptive.ServiceAccount)
 
     def test_create_serviceaccount(self, request_mock):
         # Update the response data with serviceaccount data.
         request_mock.json = dtapiresponses.serviceaccount1
 
         # Call the appropriate endpoint.
-        s = dt.ServiceAccount.create_serviceaccount(
+        s = disruptive.ServiceAccount.create_serviceaccount(
             'project_id',
             'new-sa',
             True,
@@ -85,7 +100,7 @@ class TestServiceAccount():
         # Verify request parameters.
         request_mock.assert_requested(
             method='POST',
-            url=dt.api_url+'/projects/project_id/serviceaccounts',
+            url=disruptive.api_url+'/projects/project_id/serviceaccounts',
             body={'displayName': 'new-sa', 'enableBasicAuth': True},
         )
 
@@ -93,14 +108,14 @@ class TestServiceAccount():
         request_mock.assert_request_count(1)
 
         # Assert attributes in output Device object.
-        assert isinstance(s, dt.ServiceAccount)
+        assert isinstance(s, disruptive.ServiceAccount)
 
     def test_update_serviceaccount(self, request_mock):
         # Update the response data with serviceaccount data.
         request_mock.json = dtapiresponses.serviceaccount1
 
         # Call the appropriate endpoint.
-        s = dt.ServiceAccount.update_serviceaccount(
+        s = disruptive.ServiceAccount.update_serviceaccount(
             serviceaccount_id='serviceaccount_id',
             project_id='project_id',
             display_name='service-account-1',
@@ -113,20 +128,20 @@ class TestServiceAccount():
         # Verify request parameters.
         request_mock.assert_requested(
             method='PATCH',
-            url=dt.api_url+'/projects/project_id/'
+            url=disruptive.api_url+'/projects/project_id/'
             + 'serviceaccounts/serviceaccount_id',
             body={'displayName': 'service-account-1', 'enableBasicAuth': False}
         )
 
         # Assert attributes in output Device object.
-        assert isinstance(s, dt.ServiceAccount)
+        assert isinstance(s, disruptive.ServiceAccount)
 
     def test_delete_serviceaccount(self, request_mock):
         # Update the response status code to 200.
         request_mock.status_code = 200
 
         # Call the appropriate endpoint.
-        dt.ServiceAccount.delete_serviceaccount(
+        disruptive.ServiceAccount.delete_serviceaccount(
             serviceaccount_id='serviceaccount_id',
             project_id='project_id',
         )
@@ -137,7 +152,7 @@ class TestServiceAccount():
         # Verify request parameters.
         request_mock.assert_requested(
             method='DELETE',
-            url=dt.api_url+'/projects/project_id/'
+            url=disruptive.api_url+'/projects/project_id/'
             + 'serviceaccounts/serviceaccount_id',
         )
 
@@ -147,7 +162,7 @@ class TestServiceAccount():
         request_mock.json = res
 
         # Call the appropriate endpoint.
-        k = dt.ServiceAccount.get_key(
+        k = disruptive.ServiceAccount.get_key(
             'serviceaccount_id',
             'key_id',
             'project_id',
@@ -164,7 +179,7 @@ class TestServiceAccount():
         request_mock.json = res
 
         # Call the appropriate endpoint.
-        k = dt.ServiceAccount.create_key(
+        k = disruptive.ServiceAccount.create_key(
             'serviceaccount_id',
             'project_id',
         )
@@ -177,7 +192,7 @@ class TestServiceAccount():
         request_mock.json = dtapiresponses.key_without_secret
 
         # Call the appropriate endpoint.
-        key = dt.ServiceAccount.get_key(
+        key = disruptive.ServiceAccount.get_key(
             serviceaccount_id='serviceaccount_id',
             key_id='key_id',
             project_id='project_id',
@@ -186,7 +201,7 @@ class TestServiceAccount():
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/projects/project_id/'
+            url=disruptive.api_url+'/projects/project_id/'
             + 'serviceaccounts/serviceaccount_id/keys/key_id',
         )
 
@@ -201,7 +216,7 @@ class TestServiceAccount():
         request_mock.json = dtapiresponses.keys
 
         # Call the appropriate endpoint.
-        keys = dt.ServiceAccount.list_keys(
+        keys = disruptive.ServiceAccount.list_keys(
             serviceaccount_id='serviceaccount_id',
             project_id='project_id',
         )
@@ -209,7 +224,7 @@ class TestServiceAccount():
         # Verify request parameters.
         request_mock.assert_requested(
             method='GET',
-            url=dt.api_url+'/projects/project_id/'
+            url=disruptive.api_url+'/projects/project_id/'
             + 'serviceaccounts/serviceaccount_id/keys',
         )
 
@@ -225,7 +240,7 @@ class TestServiceAccount():
         request_mock.json = dtapiresponses.key_with_secret
 
         # Call the appropriate endpoint.
-        key = dt.ServiceAccount.create_key(
+        key = disruptive.ServiceAccount.create_key(
             serviceaccount_id='serviceaccount_id',
             project_id='project_id',
         )
@@ -233,7 +248,7 @@ class TestServiceAccount():
         # Verify request parameters.
         request_mock.assert_requested(
             method='POST',
-            url=dt.api_url+'/projects/project_id/'
+            url=disruptive.api_url+'/projects/project_id/'
             + 'serviceaccounts/serviceaccount_id/keys',
         )
 
@@ -248,7 +263,7 @@ class TestServiceAccount():
         request_mock.status_code = 200
 
         # Call the appropriate endpoint.
-        dt.ServiceAccount.delete_key(
+        disruptive.ServiceAccount.delete_key(
             serviceaccount_id='serviceaccount_id',
             key_id='key_id',
             project_id='project_id',
@@ -257,7 +272,7 @@ class TestServiceAccount():
         # Verify request parameters.
         request_mock.assert_requested(
             method='DELETE',
-            url=dt.api_url+'/projects/project_id/'
+            url=disruptive.api_url+'/projects/project_id/'
             + 'serviceaccounts/serviceaccount_id/keys/key_id',
         )
 


### PR DESCRIPTION
- Added generic `__repr__()` dunder to OutputBase class which is inherited by almost all resources.
- Those who have a custom constructor, like EventHistory and Auth, got their own `__repr__`.
- It should work with `eval(repr(x))`.
- Tests have also been written in the form of `test_repr()`.
- Dunder `__str__` has been modified to be more similar to the python typing format.