### PR TITLE
double timezone fix

### DIFF
--- a/disruptive/transforms.py
+++ b/disruptive/transforms.py
@@ -33,7 +33,13 @@ def to_iso8601(ts):
     # If not string, datetime is also fine as it can be converted.
     elif isinstance(ts, datetime):
         # Use built-in functions for converting to string.
-        return ts.isoformat() + 'Z'
+        dt = ts.isoformat()
+
+        # Add timezone information if lacking.
+        if '+' not in dt:
+            dt += 'Z'
+
+        return dt
 
     # If ts is None, return None.
     elif ts is None:


### PR DESCRIPTION
If datetime object has been created with timezone info, `isoformat()` outputs `+00:00` suffix which breaks when adding `Z` like before. Now, only add `Z` if no timezone info exists.