### PR TITLE
Class type-constants

### DIFF
--- a/disruptive/resources/dataconnector.py
+++ b/disruptive/resources/dataconnector.py
@@ -42,6 +42,10 @@ class DataConnector(dtoutputs.OutputBase):
 
     """
 
+    # Constants for the various dataconnector configuration types.
+    HTTP_PUSH = 'HttpPush'
+    DATACONNECTOR_TYPES = [HTTP_PUSH]
+
     def __init__(self, dataconnector: dict) -> None:
         """
         Constructs the DataConnector object by unpacking

--- a/disruptive/resources/device.py
+++ b/disruptive/resources/device.py
@@ -37,6 +37,19 @@ class Device(dtoutputs.OutputBase):
 
     """
 
+    # Constants for the various device types.
+    TEMPERATURE = 'temperature'
+    PROXIMITY = 'proximity'
+    TOUCH = 'touch'
+    HUMIDITY = 'humidity'
+    PROXIMITY_COUNTER = 'proximityCounter'
+    TOUCH_COUNTER = 'touchCounter'
+    WATER_DETECTOR = 'waterDetector'
+    DEVICE_TYPES = [
+        TEMPERATURE, PROXIMITY, TOUCH, HUMIDITY,
+        PROXIMITY_COUNTER, TOUCH_COUNTER, WATER_DETECTOR
+    ]
+
     def __init__(self, device: dict) -> None:
         """
         Constructs the Device object by unpacking the raw device response.

--- a/disruptive/resources/role.py
+++ b/disruptive/resources/role.py
@@ -25,6 +25,14 @@ class Role(OutputBase):
 
     """
 
+    # Constants for the available roles.
+    PROJECT_USER = 'project.user'
+    PROJECT_DEVELOPER = 'project.developer'
+    PROJECT_ADMIN = 'project.admin'
+    ORGANIZATION_ADMIN = 'organization.admin'
+    ROLES = [PROJECT_USER, PROJECT_DEVELOPER, PROJECT_ADMIN,
+             ORGANIZATION_ADMIN]
+
     def __init__(self, role: dict) -> None:
         """
         Constructs the Role object by unpacking the raw role response.

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -21,5 +21,5 @@
 }
 
 dd {
-    margin-top: 15px;
+    margin-top: 0px;
 }

--- a/docs/content/api-reference/resources/dataconnector/dataconnector.rst
+++ b/docs/content/api-reference/resources/dataconnector/dataconnector.rst
@@ -16,8 +16,15 @@ Class
 ^^^^^
 .. autoclass:: disruptive.DataConnector
 
-Type-Specific Configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   .. rubric:: Data Connector Type Constants
+   .. compound::
+      The DataConnector resources class contains one string constant for each configuration type available, including a list of all types.
+
+   .. autoattribute:: disruptive.DataConnector.HTTP_PUSH
+   .. autoattribute:: disruptive.DataConnector.DATACONNECTOR_TYPES
+
+Configuration Classes
+^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: disruptive.dataconnector_configs.HttpPush
    
    .. automethod:: disruptive.dataconnector_configs.HttpPush.__init__

--- a/docs/content/api-reference/resources/device/device.rst
+++ b/docs/content/api-reference/resources/device/device.rst
@@ -1,9 +1,9 @@
 Device
-------
+======
 The Device class can be used to fetch and manipulate your devices, from listing the ones in a project to setting labels.
 
 API Methods
-^^^^^^^^^^^
+-----------
 .. autofunction:: disruptive.Device.get_device
 .. autofunction:: disruptive.Device.list_devices
 .. autofunction:: disruptive.Device.batch_update_labels
@@ -12,8 +12,32 @@ API Methods
 .. autofunction:: disruptive.Device.transfer_devices
 
 Class
-^^^^^
+-----
 .. autoclass:: disruptive.Device
+
+   .. rubric:: Device Type Constants
+   .. compound::
+      The Device resources class contains one string constant for each device type available, including a list of all types.
+
+   .. code-block:: python
+
+      # List all temperature- and touch sensors in a project.
+      devices = dt.Device.list_devices(
+          project_id,
+          device_types=[
+              dt.Device.TEMPERATURE,
+              dt.Device.TOUCH,
+          ],
+      )
+
+   .. autoattribute:: disruptive.Device.TEMPERATURE
+   .. autoattribute:: disruptive.Device.PROXIMITY
+   .. autoattribute:: disruptive.Device.TOUCH
+   .. autoattribute:: disruptive.Device.HUMIDITY
+   .. autoattribute:: disruptive.Device.PROXIMITY_COUNTER
+   .. autoattribute:: disruptive.Device.TOUCH_COUNTER
+   .. autoattribute:: disruptive.Device.WATER_DETECTOR
+   .. autoattribute:: disruptive.Device.DEVICE_TYPES
 
 .. toctree::
    :hidden:

--- a/docs/content/api-reference/resources/role/role.rst
+++ b/docs/content/api-reference/resources/role/role.rst
@@ -10,3 +10,21 @@ API Methods
 Class
 ^^^^^
 .. autoclass:: disruptive.Role
+
+   .. rubric:: Available Roles Constants
+   .. compound::
+      The Role resources class contains one string constant for each available role, including a list of all types.
+
+   .. code-block:: python
+
+      # Add a new developer member to the specified project.
+      dt.Project.add_member(
+          project_id,
+          email,
+          roles=[dt.Role.PROJECT_DEVELOPER],
+      )
+
+   .. autoattribute:: disruptive.Role.PROJECT_USER
+   .. autoattribute:: disruptive.Role.PROJECT_DEVELOPER
+   .. autoattribute:: disruptive.Role.PROJECT_ADMIN
+   .. autoattribute:: disruptive.Role.ORGANIZATION_ADMIN


### PR DESCRIPTION
Added string constants to resources classes Device, DataConnector, and Role on the form `disruptive.<Resource>.<SOME_TYPE>.` These can be used in favor of writing strings directly.