### PR TITLE
request-retries-log-fix

### DIFF
--- a/disruptive/requests.py
+++ b/disruptive/requests.py
@@ -161,7 +161,7 @@ class DTRequest():
 
             dtlog.log("Got error {}. Will retry up to {} more times".format(
                 error,
-                dt.request_retries - nth_attempt,
+                self.request_retries - nth_attempt,
             ), override=self.log)
 
             # Sleep if necessary.


### PR DESCRIPTION
Fixed bug where if `request_retries` were overridden, the log would still show the default value.