### PR TITLE
Generic Errors

### DIFF
--- a/disruptive/authentication.py
+++ b/disruptive/authentication.py
@@ -121,7 +121,7 @@ class Auth():
         for key in credentials:
             # Verify credential is type string.
             if isinstance(credentials[key], str):
-                # Raise ValueError if string is empty.
+                # Raise EmptyStringError if string is empty.
                 # This typically happens is credentials are fetched from
                 # the environment with a fallback to an empty string.
                 if len(credentials[key]) == 0:
@@ -132,7 +132,7 @@ class Auth():
 
             # If not, raise TypeError.
             else:
-                raise dterrors.TypeError(
+                raise TypeError(
                     'Authentication credential <{}> got type <{}>. '
                     'Expected <str>.'.format(
                         key, type(credentials[key]).__name__

--- a/disruptive/errors.py
+++ b/disruptive/errors.py
@@ -146,26 +146,6 @@ class EmptyStringError(DTApiError):
         super().__init__(message)
 
 
-class TypeError(DTApiError):
-    """
-    Unexpected type.
-
-    """
-
-    def __init__(self, message):
-        super().__init__(message)
-
-
-class ValueError(DTApiError):
-    """
-    Unexpected value.
-
-    """
-
-    def __init__(self, message):
-        super().__init__(message)
-
-
 class UnknownError(DTApiError):
     """
     An unexpected error has been raised.

--- a/disruptive/transforms.py
+++ b/disruptive/transforms.py
@@ -44,7 +44,7 @@ def to_iso8601(ts):
     else:
         msg = 'Got timestamp of type <{}>, expected ' \
             'iso8601 <str> or <datetime>.'.format(type(ts).__name__)
-        raise dterrors.TypeError(msg)
+        raise TypeError(msg)
 
 
 def to_datetime(ts):
@@ -75,7 +75,7 @@ def to_datetime(ts):
             'iso8601 <str> or <datetime>.'.format(
                 type(ts).__name__
             )
-        raise dterrors.TypeError(msg)
+        raise TypeError(msg)
 
 
 def validate_iso8601_format(dt_str):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -56,11 +56,11 @@ class TestAuth():
 
     def test_raise_none_credential(self):
         # Verify TypeError raised at None input credential.
-        with pytest.raises(dterrors.TypeError):
+        with pytest.raises(TypeError):
             disruptive.Auth.serviceaccount(None, 'secret', 'email')
-        with pytest.raises(dterrors.TypeError):
+        with pytest.raises(TypeError):
             disruptive.Auth.serviceaccount('key_id', None, 'email')
-        with pytest.raises(dterrors.TypeError):
+        with pytest.raises(TypeError):
             disruptive.Auth.serviceaccount('key_id', 'secret', None)
 
     def test_raise_empty_string_credential(self):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -17,7 +17,7 @@ class TestTransforms():
 
     def test_to_iso8601_invalid_type(self):
         inp = {'timestamp': '1970-01-01T00:00:00Z'}
-        with pytest.raises(dterrors.TypeError):
+        with pytest.raises(TypeError):
             dttrans.to_iso8601(inp)
 
     def test_to_iso8601_none(self):
@@ -57,7 +57,7 @@ class TestTransforms():
 
     def test_to_datetime_invalid_type(self):
         inp = {'timestamp': datetime(1970, 1, 1)}
-        with pytest.raises(dterrors.TypeError):
+        with pytest.raises(TypeError):
             dttrans.to_datetime(inp)
 
     def test_to_datetime_none(self):


### PR DESCRIPTION
Removed disruptive.errors.TypeError and disruptive.errors.ValueError in favor of TypeError and ValueError respectively.