### PR TITLE
Stream simplify

### DIFF
--- a/disruptive/resources/stream.py
+++ b/disruptive/resources/stream.py
@@ -16,66 +16,15 @@ class Stream():
     """
 
     @staticmethod
-    def device(device_id: str,
-               project_id: str,
-               event_types: Optional[list[str]] = None,
-               **kwargs,
-               ) -> Generator:
+    def event_stream(project_id: str,
+                     device_ids: Optional[list[str]] = None,
+                     label_filters: Optional[list[str]] = None,
+                     device_types: Optional[list[str]] = None,
+                     event_types: Optional[list[str]] = None,
+                     **kwargs,
+                     ) -> Generator:
         """
-        Streams events for a single device.
-
-        Implements a basic retry-routine. If connection is lost, the stream
-        will attempt to reconnect with an exponential backoff. Potential
-        lost events while reconnecting are, however, not acocunted for.
-
-        Parameters
-        ----------
-        device_id : str
-            Unique ID of the target device.
-        project_id : str
-            Unique ID of the target project.
-        auth: Auth, optional
-            Authorization object used to authenticate the REST API.
-            If provided it will be prioritized over global authentication.
-
-        Returns
-        -------
-        stream : Generator
-            A python Generator type that yields each new event in the stream.
-
-        Examples
-        --------
-        >>> # Stream real-time events from a single device.
-        >>> for event in dt.Stream.device('<DEVICE_ID>', '<PROJECT_ID>'):
-        ...     print(event)
-
-        """
-
-        # Construct URL.
-        url = '/projects/{}/devices/{}:stream'.format(
-            project_id,
-            device_id
-        )
-
-        # Construct parameters dictionary.
-        params: dict = dict()
-        if event_types is not None:
-            params['event_types'] = event_types
-
-        # Relay generator output.
-        for event in dtrequests.DTRequest.stream(url, params=params, **kwargs):
-            yield Event(event)
-
-    @staticmethod
-    def project(project_id: str,
-                device_ids: Optional[list[str]] = None,
-                label_filters: Optional[list[str]] = None,
-                device_types: Optional[list[str]] = None,
-                event_types: Optional[list[str]] = None,
-                **kwargs,
-                ) -> Generator:
-        """
-        Streams events for a multiple devices in a project.
+        Streams events for one, several, or all devices in a project.
 
         Implements a basic retry-routine. If connection is lost, the stream
         will attempt to reconnect with an exponential backoff. Potential
@@ -105,14 +54,27 @@ class Stream():
         Examples
         --------
         >>> # Stream real-time events from all devices in a project.
-        >>> for event in dt.Stream.project('<PROJECT_ID>'):
+        >>> for event in dt.Stream.event_stream('<PROJECT_ID>'):
         ...     print(event)
 
-        >>> # Stream from all temperature- and touch sensors with a 'v1' label.
-        >>> for e in dt.Stream.project(project_id='<PROJECT_ID>',
-        ...                            device_types=['temperature', 'touch'],
-        ...                            label_filters=['v1'],
-        ...                            ):
+        >>> # Stream real-time events from one device in a project.
+        >>> for event in dt.Stream.event_stream(project_id='<PROJECT_ID>',
+        ...                                     device_ids=['<DEVICE_ID>'],
+        ...                                     ):
+        ...     print(event)
+
+        >>> # Stream real-time touch events from a select list of
+        >>> # humidity- and touch sensors, but only those with a 'v1' label.
+        >>> for e in dt.Stream.event_stream(project_id='<PROJECT_ID>',
+        ...                                 device_ids=[
+        ...                                     '<DEVICE_ID_1>',
+        ...                                     '<DEVICE_ID_2>',
+        ...                                     '<DEVICE_ID_3>',
+        ...                                 ]
+        ...                                 event_types=['touch'],
+        ...                                 device_types=['humidity', 'touch'],
+        ...                                 label_filters=['v1'],
+        ...                                 ):
         ...     print(e.data)
 
         """

--- a/docs/examples/threaded_stream.rst
+++ b/docs/examples/threaded_stream.rst
@@ -1,6 +1,6 @@
 Threaded Stream
 ===============
-In this example, the :code:`disruptive.Stream.project()` resource method and built-in `threading` package is used together to continuously stream events in a separate thread, independent of the main program. Every time a new event appears in the stream it is appended to a buffer list which is accessible from the main thread.
+In this example, the :code:`disruptive.Stream.event_stream()` resource method and built-in `threading` package is used together to continuously stream events in a separate thread, independent of the main program. Every time a new event appears in the stream it is appended to a buffer list which is accessible from the main thread.
 
 Full Example
 ------------
@@ -27,7 +27,7 @@ The following snippet implements the example. Remember to set the environment va
    # Function which will be the target for our thread.
    def stream_worker(project_id: str):
        # Create stream generator
-       for new_event in dt.Stream.project(project_id):
+       for new_event in dt.Stream.event_stream(project_id):
            # When a new event arrives, lock buffer before writing.
            print('[Thread] New Event')
            with buffer_lock:
@@ -85,7 +85,7 @@ When using the `threading` package, the target code to be ran in the newly spawn
    # Function which will be the target for our thread.
    def stream_worker(project_id):
        # Create stream generator
-       for new_event in dt.Stream.project(project_id):
+       for new_event in dt.Stream.event_stream(project_id):
            # When a new event arrives, lock buffer before writing.
            print('[Thread] New Event')
            with buffer_lock:

--- a/docs/resources/dataconnector/metrics.rst
+++ b/docs/resources/dataconnector/metrics.rst
@@ -1,3 +1,3 @@
 Metrics
 ^^^^^^^
-.. autoclass:: disruptive.outputs.Metric
+.. autoclass:: disruptive.resources.dataconnector.Metric

--- a/docs/resources/stream/stream.rst
+++ b/docs/resources/stream/stream.rst
@@ -4,14 +4,11 @@ Stream
 ------
 The Stream resource can be used to stream device :ref:`Events <event>` in real-time. This can be achieved by using the API Methods included in the class.
 
-- :ref:`device() <stream_device>`
-- :ref:`project() <stream_project>`
+- :ref:`event_stream() <event_stream>`
 
 Each new event in the stream is represented by an instance of the :ref:`Event <event>` class.
 
 API Methods
 ^^^^^^^^^^^
-.. _stream_device:
-.. autofunction:: disruptive.Stream.device
-.. _stream_project:
-.. autofunction:: disruptive.Stream.project
+.. _event_stream:
+.. autofunction:: disruptive.Stream.event_stream

--- a/examples/threaded_stream.py
+++ b/examples/threaded_stream.py
@@ -17,7 +17,7 @@ dt.default_auth = dt.Auth.serviceaccount(key_id, secret, email)
 # Function which will be the target for our thread.
 def stream_worker(project_id: str):
     # Create stream generator
-    for new_event in dt.Stream.project(project_id):
+    for new_event in dt.Stream.event_stream(project_id):
         # When a new event arrives, lock buffer before writing.
         print('[Thread] New Event')
         with buffer_lock:

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -15,32 +15,9 @@ from disruptive.events import Event
 
 class TestStream():
 
-    def test_device_arguments(self, request_mock):
+    def test_event_stream_arguments(self, request_mock):
         # Call stream with customer kwargs.
-        for event in disruptive.Stream.device(
-            device_id='device_id',
-            project_id='project_id',
-            event_types=['temperature', 'touch'],
-            request_attempts=9,
-        ):
-            pass
-
-        url = disruptive.api_url
-        url += '/projects/project_id/devices/device_id:stream'
-        request_mock.assert_requested(
-            method='GET',
-            url=url,
-            params={
-                'event_types': ['temperature', 'touch'],
-                'ping_interval': '10s',
-            },
-            stream=True,
-            timeout=12,
-        )
-
-    def test_project_arguments(self, request_mock):
-        # Call stream with customer kwargs.
-        for event in disruptive.Stream.project(
+        for event in disruptive.Stream.event_stream(
             project_id='project_id',
             device_ids=['id1', 'id2', 'id3'],
             label_filters=['l1', 'l2'],
@@ -78,7 +55,7 @@ class TestStream():
 
         # Mock logging function, which should trigger once for each ping.
         with patch('disruptive.logging.debug') as log_mock:
-            for event in disruptive.Stream.device('device_id', 'project_id'):
+            for event in disruptive.Stream.event_stream('project_id'):
                 pass
 
             # Assert logging called with expected message.
@@ -108,7 +85,7 @@ class TestStream():
         ]
 
         # Start the stream.
-        for i, event in enumerate(disruptive.Stream.project('project_id')):
+        for i, event in enumerate(disruptive.Stream.event_stream('project_id')):
             # Compare stream event to expected events.
             assert event._raw == expected[i]._raw
 
@@ -122,7 +99,7 @@ class TestStream():
         # Catch ConnectionError caused by exhausted retries.
         with pytest.raises(dterrors.ReadTimeout):
             # Start a stream, which should rause an error causing retries.
-            for event in disruptive.Stream.project(
+            for event in disruptive.Stream.event_stream(
                     project_id='project_id',
                     request_attempts=8):
                 pass
@@ -140,7 +117,7 @@ class TestStream():
         # Catch ConnectionError caused by exhausted retries.
         with pytest.raises(dterrors.ConnectionError):
             # Start a stream, which should rause an error causing retries.
-            for event in disruptive.Stream.project(
+            for event in disruptive.Stream.event_stream(
                     project_id='project_id',
                     request_attempts=7):
                 pass


### PR DESCRIPTION
Removed `disruptive.Stream.device()` and renamed `disruptive.Stream.project()` to `disruptive.Stream.event_stream()`.