### PR TITLE
Batch errors

### DIFF
--- a/disruptive/errors.py
+++ b/disruptive/errors.py
@@ -1,6 +1,20 @@
 import requests
 
+import disruptive.outputs as dtoutputs
 import disruptive.logging as dtlog
+
+
+class BatchError(dtoutputs.OutputBase):
+
+    def __init__(self, error):
+        # Inherit from OutputBase parent.
+        super().__init__(error)
+
+        # Unpack error dictionary.
+        self.device_id = error['device'].split('/')[-1]
+        self.project_id = error['device'].split('/')[1]
+        self.status_code = error['status']['code']
+        self.message = error['status']['message']
 
 
 def _raise_provided(error, message: str):

--- a/disruptive/errors.py
+++ b/disruptive/errors.py
@@ -4,10 +4,10 @@ import disruptive.outputs as dtoutputs
 import disruptive.logging as dtlog
 
 
-class BatchError(dtoutputs.OutputBase):
+class LabelUpdateError(dtoutputs.OutputBase):
     """
-    Represents problems with batch-style operations where one or several
-    of the actions failed, but the method itself is successful.
+    Represents errors that occur when a label can, for some reason, not
+    be updated for a device.
 
     Attributes
     ----------
@@ -16,7 +16,38 @@ class BatchError(dtoutputs.OutputBase):
     project_id : str
         Unique ID of the source project.
     status_code : str
-        A status code for the returned error.
+        A status code for the returned error. Is either
+        "INVALID_ARGUMENT", "NOT_FOUND", or "INTERNAL_ERROR".
+    message : str
+        Described the cause of the error.
+
+    """
+
+    def __init__(self, error):
+        # Inherit from OutputBase parent.
+        super().__init__(error)
+
+        # Unpack error dictionary.
+        self.device_id = error['device'].split('/')[-1]
+        self.project_id = error['device'].split('/')[1]
+        self.status_code = error['status']['code']
+        self.message = error['status']['message']
+
+
+class TransferDeviceError(dtoutputs.OutputBase):
+    """
+    Represents errors that occur when a device can, for some reason, not
+    be transferred from one project to another.
+
+    Attributes
+    ----------
+    device_id : str
+        Unique ID of the source device.
+    project_id : str
+        Unique ID of the source project.
+    status_code : str
+        A status code for the returned error. Is either
+        "INVALID_ARGUMENT", "NOT_FOUND", or "INTERNAL_ERROR".
     message : str
         Described the cause of the error.
 

--- a/disruptive/errors.py
+++ b/disruptive/errors.py
@@ -5,6 +5,22 @@ import disruptive.logging as dtlog
 
 
 class BatchError(dtoutputs.OutputBase):
+    """
+    Represents problems with batch-style operations where one or several
+    of the actions failed, but the method itself is successful.
+
+    Attributes
+    ----------
+    device_id : str
+        Unique ID of the source device.
+    project_id : str
+        Unique ID of the source project.
+    status_code : str
+        A status code for the returned error.
+    message : str
+        Described the cause of the error.
+
+    """
 
     def __init__(self, error):
         # Inherit from OutputBase parent.

--- a/disruptive/outputs.py
+++ b/disruptive/outputs.py
@@ -2,7 +2,7 @@
 import disruptive.transforms as dttrans
 
 
-class OutputBase():
+class OutputBase(object):
     """
     Represents common features for all returnable objects.
 

--- a/disruptive/resources/device.py
+++ b/disruptive/resources/device.py
@@ -6,7 +6,7 @@ import disruptive.logging as dtlog
 import disruptive.requests as dtrequests
 import disruptive.events.events as dtevents
 import disruptive.outputs as dtoutputs
-from disruptive.errors import BatchError
+from disruptive.errors import TransferDeviceError
 
 
 class Device(dtoutputs.OutputBase):
@@ -266,7 +266,7 @@ class Device(dtoutputs.OutputBase):
         )
 
         # Return any transferErrors found in response.
-        return [BatchError(err) for err in response['transferErrors']]
+        return [TransferDeviceError(err) for err in response['transferErrors']]
 
     @staticmethod
     def set_label(device_id: str,

--- a/disruptive/resources/device.py
+++ b/disruptive/resources/device.py
@@ -6,7 +6,7 @@ import disruptive.logging as dtlog
 import disruptive.requests as dtrequests
 import disruptive.events.events as dtevents
 import disruptive.outputs as dtoutputs
-from disruptive.errors import TransferDeviceError
+from disruptive.errors import TransferDeviceError, LabelUpdateError
 
 
 class Device(dtoutputs.OutputBase):
@@ -208,7 +208,7 @@ class Device(dtoutputs.OutputBase):
                          source_project_id: str,
                          target_project_id: str,
                          **kwargs,
-                         ) -> None:
+                         ) -> list[TransferDeviceError]:
         """
         Transfers all specified devices to the target project.
 
@@ -229,7 +229,7 @@ class Device(dtoutputs.OutputBase):
 
         Returns
         -------
-        errors : list[BatchError]
+        errors : list[TransferDeviceError]
             A list that contains one error object for each device that
             could not be successfully transferred.
 
@@ -274,7 +274,7 @@ class Device(dtoutputs.OutputBase):
                   key: str,
                   value: str,
                   **kwargs,
-                  ) -> None:
+                  ) -> list[LabelUpdateError]:
         """
         Set a label (key and value) for a single device.
 
@@ -293,6 +293,12 @@ class Device(dtoutputs.OutputBase):
         **kwargs
             Arbitrary keyword arguments.
             See the :ref:`Configuration <configuration>` page.
+
+        Returns
+        -------
+        errors : list[LabelUpdateError]
+            A list that contains one error object for each label that
+            could not be successfully updated.
 
         Examples
         --------
@@ -314,15 +320,18 @@ class Device(dtoutputs.OutputBase):
         body['devices'] = ['projects/' + project_id + '/devices/' + device_id]
         body['addLabels'] = {key: value}
 
-        # Sent POST request, but return nothing.
-        dtrequests.DTRequest.post(url, body=body, **kwargs)
+        # Sent POST request.
+        response = dtrequests.DTRequest.post(url, body=body, **kwargs)
+
+        # Return any batchErrors found in response.
+        return [LabelUpdateError(err) for err in response['batchErrors']]
 
     @staticmethod
     def remove_label(device_id: str,
                      project_id: str,
                      key: str,
                      **kwargs,
-                     ) -> None:
+                     ) -> list[LabelUpdateError]:
         """
         Remove a label (key and value) from a single device.
 
@@ -337,6 +346,12 @@ class Device(dtoutputs.OutputBase):
         **kwargs
             Arbitrary keyword arguments.
             See the :ref:`Configuration <configuration>` page.
+
+        Returns
+        -------
+        errors : list[LabelUpdateError]
+            A list that contains one error object for each label that
+            could not be successfully updated.
 
         Examples
         --------
@@ -357,8 +372,11 @@ class Device(dtoutputs.OutputBase):
         body['devices'] = ['projects/' + project_id + '/devices/' + device_id]
         body['removeLabels'] = [key]
 
-        # Sent POST request, but return nothing.
-        dtrequests.DTRequest.post(url, body=body, **kwargs)
+        # Sent POST request.
+        response = dtrequests.DTRequest.post(url, body=body, **kwargs)
+
+        # Return any batchErrors found in response.
+        return [LabelUpdateError(err) for err in response['batchErrors']]
 
     @staticmethod
     def batch_update_labels(device_ids: list[str],
@@ -366,7 +384,7 @@ class Device(dtoutputs.OutputBase):
                             set_labels: Optional[dict[str, str]] = None,
                             remove_labels: Optional[list[str]] = None,
                             **kwargs,
-                            ) -> None:
+                            ) -> list[LabelUpdateError]:
         """
         Add, update, or remove multiple labels (key and value)
         on multiple devices
@@ -388,6 +406,12 @@ class Device(dtoutputs.OutputBase):
         **kwargs
             Arbitrary keyword arguments.
             See the :ref:`Configuration <configuration>` page.
+
+        Returns
+        -------
+        errors : list[LabelUpdateError]
+            A list that contains one error object for each label that
+            could not be successfully updated.
 
         Raises
         ------
@@ -435,8 +459,11 @@ class Device(dtoutputs.OutputBase):
         # Construct URL.
         url = '/projects/{}/devices:batchUpdate'.format(project_id)
 
-        # Sent POST request, but return nothing.
-        dtrequests.DTRequest.post(url, body=body, **kwargs)
+        # Sent POST request.
+        response = dtrequests.DTRequest.post(url, body=body, **kwargs)
+
+        # Return any batchErrors found in response.
+        return [LabelUpdateError(err) for err in response['batchErrors']]
 
 
 class Reported(dtoutputs.OutputBase):

--- a/disruptive/resources/device.py
+++ b/disruptive/resources/device.py
@@ -6,7 +6,7 @@ import disruptive.logging as dtlog
 import disruptive.requests as dtrequests
 import disruptive.events.events as dtevents
 import disruptive.outputs as dtoutputs
-import disruptive.errors as dterrors
+from disruptive.errors import BatchError
 
 
 class Device(dtoutputs.OutputBase):
@@ -227,10 +227,16 @@ class Device(dtoutputs.OutputBase):
             Arbitrary keyword arguments.
             See the :ref:`Configuration <configuration>` page.
 
+        Returns
+        -------
+        errors : list[BatchError]
+            A list that contains one error object for each device that
+            could not be successfully transferred.
+
         Examples
         --------
         >>> # Move a device from on project to another.
-        >>> disruptive.Device.transfer_devices(
+        >>> err = disruptive.Device.transfer_devices(
         ...     device_ids=[
         ...         '<DEVICE_ID_1>',
         ...         '<DEVICE_ID_2',
@@ -260,7 +266,7 @@ class Device(dtoutputs.OutputBase):
         )
 
         # Return any transferErrors found in response.
-        return [dterrors.BatchError(err) for err in response['transferErrors']]
+        return [BatchError(err) for err in response['transferErrors']]
 
     @staticmethod
     def set_label(device_id: str,

--- a/disruptive/resources/device.py
+++ b/disruptive/resources/device.py
@@ -6,6 +6,7 @@ import disruptive.logging as dtlog
 import disruptive.requests as dtrequests
 import disruptive.events.events as dtevents
 import disruptive.outputs as dtoutputs
+import disruptive.errors as dterrors
 
 
 class Device(dtoutputs.OutputBase):
@@ -249,14 +250,17 @@ class Device(dtoutputs.OutputBase):
             "devices": devices
         }
 
-        # Sent POST request, but return nothing.
-        dtrequests.DTRequest.post(
+        # Sent POST request.
+        response = dtrequests.DTRequest.post(
             url='/projects/{}/devices:transfer'.format(
                 target_project_id
             ),
             body=body,
             **kwargs,
         )
+
+        # Return any transferErrors found in response.
+        return [dterrors.BatchError(err) for err in response['transferErrors']]
 
     @staticmethod
     def set_label(device_id: str,

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -1,5 +1,6 @@
 Exceptions
 ==========
+If the API returns a non-200 status code, or something unexpected occurs, and exception is raised.
 
 .. _badrequest:
 .. autoexception:: disruptive.errors.BadRequest
@@ -14,3 +15,9 @@ Exceptions
 .. autoexception:: disruptive.errors.FormatError
 .. autoexception:: disruptive.errors.ConfigurationError
 .. autoexception:: disruptive.errors.UnknownError
+
+Errors
+------
+Unlike exceptions, errors and not raised, but a class object returned to the user with information for them to deal with as they see fit. Errors are only returned by batch-style functions like :ref:`transfer_devices() <transfer_devices>` and :ref:`batch_update_labels() <batch_update_labels>`.
+
+.. autoclass:: disruptive.errors.BatchError

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -20,4 +20,5 @@ Errors
 ------
 Unlike exceptions, errors and not raised, but a class object returned to the user with information for them to deal with as they see fit. Errors are only returned by batch-style functions like :ref:`transfer_devices() <transfer_devices>` and :ref:`batch_update_labels() <batch_update_labels>`.
 
-.. autoclass:: disruptive.errors.BatchError
+.. autoclass:: disruptive.errors.TransferDeviceError
+.. autoclass:: disruptive.errors.LabelUpdateError

--- a/tests/api_responses.py
+++ b/tests/api_responses.py
@@ -859,3 +859,22 @@ transfer_device_errors = {
         },
     ],
 }
+
+batch_label_response = {
+    "batchErrors": [
+        {
+            "device": "/projects/<source_project_id>/devices/<device_id_1>",
+            "status": {
+                "code": "INVALID_ARGUMENT",
+                "message": "Max labels reached for device."
+            }
+        },
+        {
+            "device": "/projects/<source_project_id>/devices/<device_id_2>",
+            "status": {
+                "code": "INTERNAL_ERROR",
+                "message": "Operation timed out. Retry again in a few seconds."
+            }
+        }
+    ]
+}

--- a/tests/api_responses.py
+++ b/tests/api_responses.py
@@ -828,3 +828,34 @@ stream_networkstatus_event = b'{"result":{"event":{"eventId":"c1vtubtd83it'\
     b'"emulated-ccon","signalStrength":99,"rssi":0}],'\
     b'"transmissionMode":"LOW_POWER_STANDARD_MODE"}},"timestamp":'\
     b'"2021-04-21T08:15:43.520167Z"}}}'
+
+transfer_device_no_errors = {
+    'transferredDevices': [
+        'projects/source_project/devices/device_id1',
+        'projects/source_project/devices/device_id2',
+    ],
+    'transferErrors': [],
+}
+
+transfer_device_errors = {
+    'transferredDevices': [
+        'projects/source_project/devices/device_id1',
+        'projects/source_project/devices/device_id2',
+    ],
+    'transferErrors': [
+        {
+            'device': 'projects/source_project/devices/123',
+            'status': {
+                'code': 'NOT_FOUND',
+                'message': 'resource not found',
+            }
+        },
+        {
+            'device': 'projects/source_project/devices/abc',
+            'status': {
+                'code': 'NOT_FOUND',
+                'message': 'resource not found',
+            }
+        },
+    ],
+}

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import disruptive
 import disruptive.events.events as dtevents
 import tests.api_responses as dtapiresponses
+import disruptive.errors as dterrors
 
 
 class TestDevice():
@@ -221,6 +222,9 @@ class TestDevice():
         assert d is None
 
     def test_transfer_devices(self, request_mock):
+        # Update the response data with transfer response data.
+        request_mock.json = dtapiresponses.transfer_device_no_errors
+
         # Call Device.remove_label() method.
         d = disruptive.Device.transfer_devices(
             device_ids=['device_id1', 'device_id2'],
@@ -244,8 +248,53 @@ class TestDevice():
         # Assert single request sent.
         request_mock.assert_request_count(1)
 
-        # Assert output is None.
-        assert d is None
+        # Assert output.
+        assert isinstance(d, list)
+        assert len(d) == 0
+
+    def test_transfer_devices_errors(self, request_mock):
+        # Update the response data with transfer response data.
+        request_mock.json = dtapiresponses.transfer_device_errors
+
+        # Define device ids to transfer.
+        good_ids = ['device_id1', 'device_id2']
+        bad_ids = ['abc', '123']
+
+        # Call Device.remove_label() method.
+        d = disruptive.Device.transfer_devices(
+            device_ids=good_ids+bad_ids,
+            source_project_id='source_project',
+            target_project_id='target_project',
+        )
+
+        # Verify expected outgoing parameters in request.
+        url = disruptive.base_url+'/projects/target_project/devices:transfer'
+        request_mock.assert_requested(
+            method='POST',
+            url=url,
+            body={
+                'devices': [
+                    'projects/source_project/devices/device_id1',
+                    'projects/source_project/devices/device_id2',
+                    'projects/source_project/devices/abc',
+                    'projects/source_project/devices/123',
+                ],
+            }
+        )
+
+        # Assert single request sent.
+        request_mock.assert_request_count(1)
+
+        # Assert output.
+        assert isinstance(d, list)
+        assert len(d) == 2
+        for e in d:
+            # List should contain BatchError.
+            assert isinstance(e, dterrors.BatchError)
+
+            # Id should be one of the bad ones.
+            assert e.device_id in bad_ids
+            assert e.device_id not in good_ids
 
     def test_reported_no_data(self, request_mock):
         # Update the response data with device data.

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -133,6 +133,9 @@ class TestDevice():
             assert isinstance(d, disruptive.Device)
 
     def test_batch_update_labels(self, request_mock):
+        # Update the response data with labelupdate response data.
+        request_mock.json = dtapiresponses.batch_label_response
+
         # Call Device.batch_update_labels() method.
         d = disruptive.Device.batch_update_labels(
             device_ids=['device_id1', 'device_id2', 'device_id3'],
@@ -164,9 +167,12 @@ class TestDevice():
         request_mock.assert_request_count(1)
 
         # Assert output is None.
-        assert d is None
+        assert isinstance(d, list)
 
     def test_set_label(self, request_mock):
+        # Update the response data with labelupdate response data.
+        request_mock.json = dtapiresponses.batch_label_response
+
         # Call Device.set_label() method.
         d = disruptive.Device.set_label(
             device_id='device_id',
@@ -192,9 +198,12 @@ class TestDevice():
         request_mock.assert_request_count(1)
 
         # Assert output is None.
-        assert d is None
+        assert isinstance(d, list)
 
     def test_remove_label(self, request_mock):
+        # Update the response data with labelupdate response data.
+        request_mock.json = dtapiresponses.batch_label_response
+
         # Call Device.remove_label() method.
         d = disruptive.Device.remove_label(
             device_id='device_id',
@@ -219,7 +228,7 @@ class TestDevice():
         request_mock.assert_request_count(1)
 
         # Assert output is None.
-        assert d is None
+        assert isinstance(d, list)
 
     def test_transfer_devices(self, request_mock):
         # Update the response data with transfer response data.
@@ -289,8 +298,8 @@ class TestDevice():
         assert isinstance(d, list)
         assert len(d) == 2
         for e in d:
-            # List should contain BatchError.
-            assert isinstance(e, dterrors.BatchError)
+            # List should contain TransferDeviceError.
+            assert isinstance(e, dterrors.TransferDeviceError)
 
             # Id should be one of the bad ones.
             assert e.device_id in bad_ids


### PR DESCRIPTION
Batch-style functions now return a list of errors where each element represents a failed action on an otherwise successful request.